### PR TITLE
Fix Local Path Resolution Issue in Sui-Framework

### DIFF
--- a/src/main/kotlin/org/move/cli/manifest/TomlDependency.kt
+++ b/src/main/kotlin/org/move/cli/manifest/TomlDependency.kt
@@ -1,5 +1,6 @@
 package org.move.cli.manifest
 
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -25,13 +26,25 @@ sealed class TomlDependency {
         override fun localPath(): Path {
             val home = System.getProperty("user.home")
             val dirName = dirName(repo, rev)
-            return Paths.get(home, ".move", dirName, subdir)
+            val path = Paths.get(home, ".move", dirName, subdir)
+            return if(Files.exists(path)){
+                path
+            }else{
+                val dirNameSpecRev = dirNameSpecRev(repo, rev)
+                Paths.get(home, ".move", dirNameSpecRev, subdir)
+            }
         }
 
         companion object {
             fun dirName(repo: String, rev: String): String {
                 val sanitizedRepoName = repo.replace(Regex("[/:.@]"), "_")
                 val revName = rev.replace('/', '_')
+                return "${sanitizedRepoName}_$revName"
+            }
+
+            fun dirNameSpecRev(repo: String, rev: String): String {
+                val sanitizedRepoName = repo.replace(Regex("[/:.@]"), "_")
+                val revName = rev.replace("/","__")
                 return "${sanitizedRepoName}_$revName"
             }
         }


### PR DESCRIPTION
### Problem
When the plugin loads dependencies and parses the local git path, the 'rev' part replaces '/' with a single '_', while the problematic path generated by sui-cli replaces '/' in 'rev' with '__', leading to the failure in loading the sui-framework.

**git local path**
sui: https___github_com_MystenLabs_sui_git_framework__testnet
intellij-move: https___github_com_MystenLabs_sui_git_framework_testnet

### Solution
I added a function called dirNameSpecRev to handle cases like sui-framework. When the original path fails to load the framework files, dirNameSpecRev is used to attempt the load.