### PR TITLE
add highlighting for attributes

### DIFF
--- a/src/main/kotlin/org/move/ide/annotator/HighlightingAnnotator.kt
+++ b/src/main/kotlin/org/move/ide/annotator/HighlightingAnnotator.kt
@@ -51,6 +51,7 @@ class HighlightingAnnotator: MvAnnotatorBase() {
             leafType == IDENTIFIER -> highlightIdentifier(parent)
             leafType == HEX_INTEGER_LITERAL -> MvColor.NUMBER
             parent is MvAssertMacroExpr -> MvColor.MACRO
+            parent is MvAttr -> MvColor.ATTRIBUTE
             parent is MvCopyExpr
                     && element.text == "copy" -> MvColor.KEYWORD
             else -> null
@@ -80,6 +81,7 @@ class HighlightingAnnotator: MvAnnotatorBase() {
         if (element is MvConst) return MvColor.CONSTANT
         if (element is MvModule) return MvColor.MODULE
         if (element is MvVectorLitExpr) return MvColor.VECTOR_LITERAL
+        if (element is MvAttrItem) return MvColor.ATTRIBUTE
 
         return when (element) {
             is MvPath -> highlightPathElement(element)

--- a/src/main/kotlin/org/move/ide/colors/MvColor.kt
+++ b/src/main/kotlin/org/move/ide/colors/MvColor.kt
@@ -44,6 +44,7 @@ enum class MvColor(humanName: String, default: TextAttributesKey? = null) {
     METHOD_CALL("Functions//Method call", Default.FUNCTION_CALL),
 
     MACRO("Functions//Macro", Default.IDENTIFIER),
+    ATTRIBUTE("Attribute", Default.METADATA),
 
     KEYWORD("Keywords//Keyword", Default.KEYWORD),
     SELF_PARAMETER("Keywords//Self Parameter", Default.KEYWORD),

--- a/src/main/resources/colors/highlighterDemoText.move
+++ b/src/main/resources/colors/highlighterDemoText.move
@@ -22,7 +22,7 @@ module 0x1::<MODULE>main</MODULE> {
 
     entry fun <ENTRY_FUNCTION>entry_fun</ENTRY_FUNCTION>() {}
     inline fun <INLINE_FUNCTION>inline_fun</INLINE_FUNCTION>() {}
-    #[view]
+    <ATTRIBUTE>#[view]</ATTRIBUTE>
     public fun <VIEW_FUNCTION>view_fun</VIEW_FUNCTION>() {}
 
     fun <METHOD>receiver</METHOD>(<SELF_PARAMETER>self</SELF_PARAMETER>: S, <VARIABLE>self</VARIABLE>: u8): u8 {

--- a/src/test/kotlin/org/move/ide/annotator/HighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/move/ide/annotator/HighlightingAnnotatorTest.kt
@@ -355,6 +355,13 @@ class HighlightingAnnotatorTest: AnnotatorTestCase(HighlightingAnnotator::class)
         }        
     """)
 
+    fun `test attribute highlighting`() = checkHighlighting("""
+        module 0x1::m {
+            <ATTRIBUTE>#</ATTRIBUTE><ATTRIBUTE>[</ATTRIBUTE><ATTRIBUTE>view</ATTRIBUTE><ATTRIBUTE>]</ATTRIBUTE>
+            fun foo() {}
+        }        
+    """)
+
 //    fun `test resource access control keywords highlighting`() = checkHighlighting(
 //        """
 //        module 0x1::m {


### PR DESCRIPTION
Hey! This PR adds highlighting for `#[attributes]`, like in Rust:

<img width="617" src="https://github.com/user-attachments/assets/bcf397fc-3236-4fd9-8201-c0bfbd7c2df4">
