### PR TITLE
add default themes colors for macros

### DIFF
--- a/src/main/resources/colors/MoveDarcula.xml
+++ b/src/main/resources/colors/MoveDarcula.xml
@@ -44,4 +44,9 @@
             <option name="EFFECT_TYPE" value="1" />
         </value>
     </option>
+    <option name="org.move.MACRO">
+        <value>
+            <option name="FOREGROUND" value="FFC66D" />
+        </value>
+    </option>
 </list>

--- a/src/main/resources/colors/MoveDefault.xml
+++ b/src/main/resources/colors/MoveDefault.xml
@@ -44,4 +44,9 @@
             <option name="EFFECT_TYPE" value="1" />
         </value>
     </option>
+    <option name="org.move.MACRO">
+        <value>
+            <option name="FOREGROUND" value="DD6718" />
+        </value>
+    </option>
 </list>


### PR DESCRIPTION
With these changes, any user will get this default highlighting for macros:


<img width="515" src="https://github.com/user-attachments/assets/c9251a7c-0b7c-4a34-a069-e128c0d2cb55">
<img width="518" src="https://github.com/user-attachments/assets/e9f1a549-7dfd-42f2-92e9-077b7170075c">
