### PR TITLE
Avoid JSON parsing errors caused by line wrapping

### DIFF
--- a/src/main/kotlin/org/move/cli/runConfigurations/aptos/Aptos.kt
+++ b/src/main/kotlin/org/move/cli/runConfigurations/aptos/Aptos.kt
@@ -203,7 +203,7 @@ data class Aptos(val cliLocation: Path, val parentDisposable: Disposable?): Disp
             }
 
         val json = processOutput.stdout
-            .lines().dropWhile { l -> !l.startsWith("{") }.joinToString("\n").trim()
+            .lines().dropWhile { l -> !l.startsWith("{") }.joinToString("").trim()
         val exitStatus = try {
             AptosExitStatus.fromJson(json)
         } catch (e: JacksonException) {


### PR DESCRIPTION
Fixes #266, where JSON parsing errors were occurring due to line wrapping in terminal outputs. After considering different solutions, I have implemented a fix. The following options were considered:

1. **(Selected)** No Line Wrapping During `joinToString`: Since JSON indentation and formatting do not affect parsing, removing line breaks will not disrupt the parsing process.

2. **(Optional)** Set `colored` to `false`: Another possible solution is to set the `colored` to `false`, which would allow the use of `GeneralCommandLine`. However, this approach disables terminal color output, which may not be desirable.

3. **(Optional)** Adjusting `PtyCommandLine`'s `COLUMN` Environment Variable: The `COLUMN` environment variable for `PtyCommandLine` can be adjusted to exceed **80** characters, which helps avoid line wrapping. But the maximum allowable value is **2500** characters, as the limit **cannot** be set to unlimited.